### PR TITLE
Use "*" as a valid "bundleDependencies" value that will bundle all dependencies.

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -1,4 +1,5 @@
 var Ignore = require("fstream-ignore")
+, minimatch = require("minimatch")
 , inherits = require("inherits")
 , path = require("path")
 , fs = require("fs")
@@ -139,10 +140,9 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
 
     // only include it at this point if it's a bundleDependency
     var bd = this.package && this.package.bundleDependencies
-    var shouldBundle = bd && bd.indexOf(entry) !== -1
-    // if we're not going to bundle it, then it doesn't count as a bundleLink
-    // if (this.bundleLinks && !shouldBundle) delete this.bundleLinks[entry]
-    return shouldBundle
+    if (!bd) return false
+    if (typeof bd === 'string') return minimatch(entry, bd)
+    return bd.indexOf(entry) !== -1
   }
   // if (this.bundled) return true
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "./fstream-npm.js",
   "dependencies": {
     "fstream-ignore": "~0.0.5",
+    "minimatch": "~0.2.4",
     "inherits": ""
   }
 }


### PR DESCRIPTION
When checking dependencies into source control, it's handy to have them in bundleDependencies as well, for commands like ``npm pack``. However, maintaining two identical lists of dependencies is rather un-DRY, so it's nice to just say "bundle ALL the dependencies".

Obviously this is inappropriate for a library module being published to the public registry, so if you're interested in merging this functionality I'd be happy to open another pull request adding a strong warning to the npm documentation about when to use this feature.