### PR TITLE
Make ignore files configurable

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -16,9 +16,9 @@ function Packer (props) {
     props = { path: props }
   }
 
-  props.ignoreFiles = [ ".npmignore",
-                        ".gitignore",
-                        "package.json" ]
+  props.ignoreFiles = props.ignoreFiles || [ ".npmignore",
+                                             ".gitignore",
+                                             "package.json" ]
 
   Ignore.call(this, props)
 


### PR DESCRIPTION
This allows applications to use custom ignore files, example use case
being deployment.

Ref nodejitsu/jitsu#83.
