### PR TITLE
return empty array instead of undefined in Packer.prototype.readRules()

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -190,7 +190,7 @@ Packer.prototype.readRules = function (buf, e) {
   } catch (er) {
     er.file = path.resolve(this.path, e)
     this.error(er)
-    return
+    return []
   }
 
   if (this === this.root) {


### PR DESCRIPTION
When trying to install browserify 0.4.5 to 1.0.0 npm crashes with the following message:

``` sh
TypeError: Cannot call method 'filter' of undefined
    at Packer.IgnoreReader.addIgnoreRules (/home/magnus/src/fstream-ignore/ignore.js:148:13)
    at Packer.IgnoreReader.addIgnoreFile (/home/magnus/src/fstream-ignore/ignore.js:133:10)
    at fs.readFile (fs.js:176:14)
    at Object.oncomplete (fs.js:297:15)
```

This happens because JSON.parse() fails in Packer.prototype.readRules() which returns undefined which in turn causes IgnoreReader.prototype.addIgnoreRules() to blow up.
