### PR TITLE
feature: always include licenses and changelogs

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -93,6 +93,12 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   // readme files should never be ignored.
   if (entry.match(/^readme(\.[^\.]*)$/i)) return true
 
+  // license files should never be ignored.
+  if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
+
+  // changelogs should never be ignored.
+  if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
+
   // special rules.  see below.
   if (entry === "node_modules" && this.packageRoot) return true
 


### PR DESCRIPTION
currently if you publish with a `files` property, only the README is included. i'd like the license and changelog to always be included as well. if you need a more thorough explanation, let me know, but it seems self-evident to me.

i'm also not sure if this even works because there are no tests. 
