### PR TITLE
Always include npm shrinkwrap data in pack

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -92,6 +92,9 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   // package.json files can never be ignored.
   if (entry === 'package.json') return true
 
+  // npm-shrinkwrap.json files can never be ignored.
+  if (entry === "npm-shrinkwrap.json") return true
+
   // readme files should never be ignored.
   if (entry.match(/^readme(\.[^\.]*)$/i)) return true
 


### PR DESCRIPTION
Packages which have a `files` property in their `package.json` file and want to publish a dependency-frozen package with [npm-shrinkwrap](https://www.npmjs.org/doc/cli/npm-shrinkwrap.html) need to explicitly state that `npm-shrinkwrap.json` file is to be included in the tarball.

NPM metadata is to be automatically included in the tarball, like `package.json` is.

Packages used to require an npm-specific file in their declaration:

```
{
  "name": "foobar",
  "version": "0.0.1",
  "files": ["build.js", "npm-shrinkwrap.json"],
}
```

Now just need to specify their own file:

```
{
  "name": "foobar",
  "version": "0.0.1",
  "files": ["build.js"],
}
```
