### PR TITLE
standard: fstream-npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ignore the output junk from the example scripts
 example/output
+node_modules/

--- a/example/dir-tar.js
+++ b/example/dir-tar.js
@@ -1,18 +1,18 @@
 // this will show what ends up in the fstream-npm package
-var P = require("fstream").DirReader
-var tar = require("tar")
+var P = require('fstream').DirReader
+var tar = require('tar')
 function f (entry) {
-  return entry.basename !== ".git"
+  return entry.basename !== '.git'
 }
 
-new P({ path: "./", type: "Directory", Directory: true, filter: f })
-  .on("package", function (p) {
-    console.error("package", p)
+new P({ path: './', type: 'Directory', Directory: true, filter: f })
+  .on('package', function (p) {
+    console.error('package', p)
   })
-  .on("ignoreFile", function (e) {
-    console.error("ignoreFile", e)
+  .on('ignoreFile', function (e) {
+    console.error('ignoreFile', e)
   })
-  .on("entry", function (e) {
+  .on('entry', function (e) {
     console.error(e.constructor.name, e.path.substr(e.root.path.length + 1))
   })
   .pipe(tar.Pack())

--- a/example/dir.js
+++ b/example/dir.js
@@ -1,25 +1,25 @@
 // this will show what ends up in the fstream-npm package
-var P = require("../")
-var DW = require("fstream").DirWriter
+var P = require('../')
+var DW = require('fstream').DirWriter
 
-var target = new DW({ Directory: true, type: "Directory",
-                      path: __dirname + "/output"})
+var target = new DW({ Directory: true, type: 'Directory',
+                      path: __dirname + '/output'})
 
 function f (entry) {
-  return entry.basename !== ".git"
+  return entry.basename !== '.git'
 }
 
-P({ path: "./", type: "Directory", isDirectory: true, filter: f })
-  .on("package", function (p) {
-    console.error("package", p)
+P({ path: './', type: 'Directory', isDirectory: true, filter: f })
+  .on('package', function (p) {
+    console.error('package', p)
   })
-  .on("ignoreFile", function (e) {
-    console.error("ignoreFile", e)
+  .on('ignoreFile', function (e) {
+    console.error('ignoreFile', e)
   })
-  .on("entry", function (e) {
+  .on('entry', function (e) {
     console.error(e.constructor.name, e.path)
   })
   .pipe(target)
-  .on("end", function () {
-    console.error("ended")
+  .on('end', function () {
+    console.error('ended')
   })

--- a/example/example.js
+++ b/example/example.js
@@ -1,12 +1,12 @@
 // this will show what ends up in the fstream-npm package
-var P = require("../")
-P({ path: "./" })
-  .on("package", function (p) {
-    console.error("package", p)
+var P = require('../')
+P({ path: './' })
+  .on('package', function (p) {
+    console.error('package', p)
   })
-  .on("ignoreFile", function (e) {
-    console.error("ignoreFile", e)
+  .on('ignoreFile', function (e) {
+    console.error('ignoreFile', e)
   })
-  .on("entry", function (e) {
+  .on('entry', function (e) {
     console.error(e.constructor.name, e.path.substr(e.root.dirname.length + 1))
   })

--- a/example/ig-tar.js
+++ b/example/ig-tar.js
@@ -1,18 +1,18 @@
 // this will show what ends up in the fstream-npm package
-var P = require("fstream-ignore")
-var tar = require("tar")
+var P = require('fstream-ignore')
+var tar = require('tar')
 function f (entry) {
-  return entry.basename !== ".git"
+  return entry.basename !== '.git'
 }
 
-new P({ path: "./", type: "Directory", Directory: true, filter: f })
-  .on("package", function (p) {
-    console.error("package", p)
+new P({ path: './', type: 'Directory', Directory: true, filter: f })
+  .on('package', function (p) {
+    console.error('package', p)
   })
-  .on("ignoreFile", function (e) {
-    console.error("ignoreFile", e)
+  .on('ignoreFile', function (e) {
+    console.error('ignoreFile', e)
   })
-  .on("entry", function (e) {
+  .on('entry', function (e) {
     console.error(e.constructor.name, e.path.substr(e.root.path.length + 1))
   })
   .pipe(tar.Pack())

--- a/example/tar.js
+++ b/example/tar.js
@@ -1,6 +1,6 @@
 // this will show what ends up in the fstream-npm package
-var P = require("../")
-var tar = require("tar")
+var P = require('../')
+var tar = require('tar')
 function f () {
   return true
 }
@@ -8,18 +8,18 @@ function f () {
 //   return entry.basename !== ".git"
 // }
 
-new P({ path: "./", type: "Directory", isDirectory: true, filter: f })
-  .on("package", function (p) {
-    console.error("package", p)
+new P({ path: './', type: 'Directory', isDirectory: true, filter: f })
+  .on('package', function (p) {
+    console.error('package', p)
   })
-  .on("ignoreFile", function (e) {
-    console.error("ignoreFile", e)
+  .on('ignoreFile', function (e) {
+    console.error('ignoreFile', e)
   })
-  .on("entry", function (e) {
+  .on('entry', function (e) {
     console.error(e.constructor.name, e.path)
   })
-  .on("end", function () {
-    console.error("ended")
+  .on('end', function () {
+    console.error('ended')
   })
   .pipe(tar.Pack())
   .pipe(process.stdout)

--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -1,7 +1,7 @@
-var Ignore = require("fstream-ignore")
-, inherits = require("inherits")
-, path = require("path")
-, fs = require("fs")
+var Ignore = require('fstream-ignore')
+var inherits = require('inherits')
+var path = require('path')
+var fs = require('fs')
 
 module.exports = Packer
 
@@ -12,13 +12,13 @@ function Packer (props) {
     return new Packer(props)
   }
 
-  if (typeof props === "string") {
+  if (typeof props === 'string') {
     props = { path: props }
   }
 
-  props.ignoreFiles = props.ignoreFiles || [ ".npmignore",
-                                             ".gitignore",
-                                             "package.json" ]
+  props.ignoreFiles = props.ignoreFiles || [ '.npmignore',
+                                             '.gitignore',
+                                             'package.json' ]
 
   Ignore.call(this, props)
 
@@ -30,7 +30,7 @@ function Packer (props) {
   // lives right next to a package.json file.
   this.bundleMagic = this.parent &&
                      this.parent.packageRoot &&
-                     this.basename === "node_modules"
+                     this.basename === 'node_modules'
 
   // in a node_modules folder, resolve symbolic links to
   // bundled dependencies when creating the package.
@@ -40,42 +40,44 @@ function Packer (props) {
   if (this === this.root ||
       this.parent &&
       this.parent.bundleMagic &&
-      this.basename.charAt(0) !== ".") {
+      this.basename.charAt(0) !== '.') {
     this.readBundledLinks()
   }
 
-
-  this.on("entryStat", function (entry, props) {
+  this.on('entryStat', function (entry, props) {
     // files should *always* get into tarballs
     // in a user-writable state, even if they're
     // being installed from some wackey vm-mounted
     // read-only filesystem.
-    entry.mode = props.mode = props.mode | 0200
+    entry.mode = props.mode = props.mode | parseInt('0200', 8)
   })
 }
 
 Packer.prototype.readBundledLinks = function () {
   if (this._paused) {
-    this.once("resume", this.addIgnoreFiles)
+    this.once('resume', this.addIgnoreFiles)
     return
   }
 
   this.pause()
-  fs.readdir(this.path + "/node_modules", function (er, list) {
+  fs.readdir(this.path + '/node_modules', function (er, list) {
     // no harm if there's no bundle
     var l = list && list.length
     if (er || l === 0) return this.resume()
 
     var errState = null
-    , then = function then (er) {
+    var then = function then (er) {
       if (errState) return
-      if (er) return errState = er, this.resume()
-      if (-- l === 0) return this.resume()
+      if (er) {
+        errState = er
+        return this.resume()
+      }
+      if (--l === 0) return this.resume()
     }.bind(this)
 
     list.forEach(function (pkg) {
-      if (pkg.charAt(0) === ".") return then()
-      var pd = this.path + "/node_modules/" + pkg
+      if (pkg.charAt(0) === '.') return then()
+      var pd = this.path + '/node_modules/' + pkg
       fs.realpath(pd, function (er, rp) {
         if (er) return then()
         this.bundleLinks = this.bundleLinks || {}
@@ -88,7 +90,7 @@ Packer.prototype.readBundledLinks = function () {
 
 Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   // package.json files can never be ignored.
-  if (entry === "package.json") return true
+  if (entry === 'package.json') return true
 
   // readme files should never be ignored.
   if (entry.match(/^readme(\.[^\.]*)$/i)) return true
@@ -100,19 +102,19 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
 
   // special rules.  see below.
-  if (entry === "node_modules" && this.packageRoot) return true
+  if (entry === 'node_modules' && this.packageRoot) return true
 
   // some files are *never* allowed under any circumstances
-  if (entry === ".git" ||
-      entry === ".lock-wscript" ||
+  if (entry === '.git' ||
+      entry === '.lock-wscript' ||
       entry.match(/^\.wafpickle-[0-9]+$/) ||
-      entry === "CVS" ||
-      entry === ".svn" ||
-      entry === ".hg" ||
+      entry === 'CVS' ||
+      entry === '.svn' ||
+      entry === '.hg' ||
       entry.match(/^\..*\.swp$/) ||
-      entry === ".DS_Store" ||
+      entry === '.DS_Store' ||
       entry.match(/^\._/) ||
-      entry === "npm-debug.log"
+      entry === 'npm-debug.log'
     ) {
     return false
   }
@@ -127,13 +129,12 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   // if they're not already present at a higher level.
   if (this.bundleMagic) {
     // bubbling up.  stop here and allow anything the bundled pkg allows
-    if (entry.indexOf("/") !== -1) return true
+    if (entry.indexOf('/') !== -1) return true
 
     // never include the .bin.  It's typically full of platform-specific
     // stuff like symlinks and .cmd files anyway.
-    if (entry === ".bin") return false
+    if (entry === '.bin') return false
 
-    var shouldBundle = false
     // the package root.
     var p = this.parent
     // the package before this one.
@@ -149,7 +150,7 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
 
     // since it's *not* a symbolic link, if we're *already* in a bundle,
     // then we should include everything.
-    if (pp && pp.package && pp.basename === "node_modules") {
+    if (pp && pp.package && pp.basename === 'node_modules') {
       return true
     }
 
@@ -169,8 +170,8 @@ Packer.prototype.addIgnoreFiles = function () {
   var entries = this.entries
   // if there's a .npmignore, then we do *not* want to
   // read the .gitignore.
-  if (-1 !== entries.indexOf(".npmignore")) {
-    var i = entries.indexOf(".gitignore")
+  if (entries.indexOf('.npmignore') !== -1) {
+    var i = entries.indexOf('.gitignore')
     if (i !== -1) {
       entries.splice(i, 1)
     }
@@ -181,9 +182,8 @@ Packer.prototype.addIgnoreFiles = function () {
   Ignore.prototype.addIgnoreFiles.call(this)
 }
 
-
 Packer.prototype.readRules = function (buf, e) {
-  if (e !== "package.json") {
+  if (e !== 'package.json') {
     return Ignore.prototype.readRules.call(this, buf, e)
   }
 
@@ -204,7 +204,7 @@ Packer.prototype.readRules = function (buf, e) {
   }
 
   this.packageRoot = true
-  this.emit("package", p)
+  this.emit('package', p)
 
   // make bundle deps predictable
   if (p.bundledDependencies && !p.bundleDependencies) {
@@ -215,10 +215,10 @@ Packer.prototype.readRules = function (buf, e) {
   if (!p.files || !Array.isArray(p.files)) return []
 
   // ignore everything except what's in the files array.
-  return ["*"].concat(p.files.map(function (f) {
-    return "!" + f
+  return ['*'].concat(p.files.map(function (f) {
+    return '!' + f
   })).concat(p.files.map(function (f) {
-    return "!" + f.replace(/\/+$/, "") + "/**"
+    return '!' + f.replace(/\/+$/, '') + '/**'
   }))
 }
 
@@ -242,20 +242,20 @@ Packer.prototype.getChildProps = function (stat) {
   return props
 }
 
-
-var order =
-  [ "package.json"
-  , ".npmignore"
-  , ".gitignore"
-  , /^README(\.md)?$/
-  , "LICENCE"
-  , "LICENSE"
-  , /\.js$/ ]
+var order = [
+  'package.json',
+  '.npmignore',
+  '.gitignore',
+  /^README(\.md)?$/,
+  'LICENCE',
+  'LICENSE',
+  /\.js$/
+]
 
 Packer.prototype.sort = function (a, b) {
-  for (var i = 0, l = order.length; i < l; i ++) {
+  for (var i = 0, l = order.length; i < l; i++) {
     var o = order[i]
-    if (typeof o === "string") {
+    if (typeof o === 'string') {
       if (a === o) return -1
       if (b === o) return 1
     } else {
@@ -265,46 +265,44 @@ Packer.prototype.sort = function (a, b) {
   }
 
   // deps go in the back
-  if (a === "node_modules") return 1
-  if (b === "node_modules") return -1
+  if (a === 'node_modules') return 1
+  if (b === 'node_modules') return -1
 
   return Ignore.prototype.sort.call(this, a, b)
 }
 
-
-
 Packer.prototype.emitEntry = function (entry) {
   if (this._paused) {
-    this.once("resume", this.emitEntry.bind(this, entry))
+    this.once('resume', this.emitEntry.bind(this, entry))
     return
   }
 
   // if there is a .gitignore, then we're going to
   // rename it to .npmignore in the output.
-  if (entry.basename === ".gitignore") {
-    entry.basename = ".npmignore"
+  if (entry.basename === '.gitignore') {
+    entry.basename = '.npmignore'
     entry.path = path.resolve(entry.dirname, entry.basename)
   }
 
   // all *.gyp files are renamed to binding.gyp for node-gyp
   // but only when they are in the same folder as a package.json file.
   if (entry.basename.match(/\.gyp$/) &&
-      this.entries.indexOf("package.json") !== -1) {
-    entry.basename = "binding.gyp"
+      this.entries.indexOf('package.json') !== -1) {
+    entry.basename = 'binding.gyp'
     entry.path = path.resolve(entry.dirname, entry.basename)
   }
 
   // skip over symbolic links
-  if (entry.type === "SymbolicLink") {
+  if (entry.type === 'SymbolicLink') {
     entry.abort()
     return
   }
 
-  if (entry.type !== "Directory") {
+  if (entry.type !== 'Directory') {
     // make it so that the folder in the tarball is named "package"
     var h = path.dirname((entry.root || entry).path)
-    , t = entry.path.substr(h.length + 1).replace(/^[^\/\\]+/, "package")
-    , p = h + "/" + t
+    var t = entry.path.substr(h.length + 1).replace(/^[^\/\\]+/, 'package')
+    var p = h + '/' + t
 
     entry.path = p
     entry.dirname = path.dirname(p)
@@ -319,11 +317,11 @@ Packer.prototype.emitEntry = function (entry) {
   // .pipe() doesn't do anythign special with "child" events, on
   // with "entry" events.
   var me = this
-  entry.on("entry", function (e) {
+  entry.on('entry', function (e) {
     if (e.parent === entry) {
       e.parent = me
-      me.emit("entry", e)
+      me.emit('entry', e)
     }
   })
-  entry.on("package", this.emit.bind(this, "package"))
+  entry.on('package', this.emit.bind(this, 'package'))
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,16 @@
     "type": "git",
     "url": "git://github.com/isaacs/fstream-npm.git"
   },
+  "scripts": {
+    "test": "standard"
+  },
   "main": "./fstream-npm.js",
   "dependencies": {
     "fstream-ignore": "^1.0.0",
     "inherits": "2"
+  },
+  "devDependencies": {
+    "standard": "^2.7.3"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
A much less noisy diff than `fstream`'s. 

I noticed while I was putting this together that `fstream-npm` doesn't have any tests, which, y'know, it probably should, so that's the next thing.

r: @iarna 
r: @isaacs