### PR TITLE
better error message when `bundledDependencies` is not an array

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -155,6 +155,12 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
 
     // only include it at this point if it's a bundleDependency
     var bd = this.package && this.package.bundleDependencies
+
+    if (bd && !Array.isArray(bd)) {
+      throw new Error(this.package.name + '\'s `bundledDependencies` should ' +
+                      'be an array')
+    }
+
     var shouldBundle = bd && bd.indexOf(entry) !== -1
     // if we're not going to bundle it, then it doesn't count as a bundleLink
     // if (this.bundleLinks && !shouldBundle) delete this.bundleLinks[entry]


### PR DESCRIPTION
Installing a package whose `bundledDependencies` is not an _Array_ yields the following error:

```
13 verbose stack TypeError: undefined is not a function
13 verbose stack     at Packer.applyIgnores (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/fstream-npm/fstream-npm.js:158:33)
13 verbose stack     at Packer.<anonymous> (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:181:17)
13 verbose stack     at Array.filter (native)
13 verbose stack     at Packer.IgnoreReader.filterEntries (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:179:31)
13 verbose stack     at Packer.<anonymous> (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:50:29)
13 verbose stack     at emitOne (events.js:77:13)
13 verbose stack     at Packer.emit (events.js:166:7)
13 verbose stack     at /home/kenan/.npm-packages/lib/node_modules/npm/node_modules/fstream/lib/dir-reader.js:53:8
13 verbose stack     at ReaddirReq.Req.done (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:141:5)
13 verbose stack     at ReaddirReq.done (/home/kenan/.npm-packages/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:88:22)
```

This patch improves the error message:

```
npm ERR! <pkg-name>'s `bundledDependencies` should be an array
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
```

I'm not sure what "subsystem" to prefix the commit message with so I'm just going with `fstream`. Also this kind of messes with the goal of https://github.com/npm/fstream-npm/pull/1 :/

Fixes https://github.com/npm/npm/issues/7635