### PR TITLE
ignores: hardcode `config.gypi` and `.npmrc`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+sudo: false
+node_js:
+  - iojs
+  - "0.12"
+  - "0.10"
+  - "0.8"
+before_install:
+  - "npm config set spin false"
+  - "npm install -g npm/npm#2.x"
+script: "npm test"
+notifications:
+    slack: npm-inc:kRqQjto7YbINqHPb1X6nS3g8

--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -109,16 +109,19 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   if (mainFile && path.resolve(this.path, entry) === path.resolve(this.path, mainFile)) return true
 
   // some files are *never* allowed under any circumstances
+  // (VCS folders, native build cruft, npm cruft, regular cruft)
   if (entry === '.git' ||
-      entry === '.lock-wscript' ||
-      entry.match(/^\.wafpickle-[0-9]+$/) ||
       entry === 'CVS' ||
       entry === '.svn' ||
       entry === '.hg' ||
+      entry === '.lock-wscript' ||
+      entry.match(/^\.wafpickle-[0-9]+$/) ||
+      entry === 'config.gypi' ||
+      entry === 'npm-debug.log' ||
+      entry === '.npmrc' ||
       entry.match(/^\..*\.swp$/) ||
       entry === '.DS_Store' ||
-      entry.match(/^\._/) ||
-      entry === 'npm-debug.log'
+      entry.match(/^\._/)
     ) {
     return false
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/isaacs/fstream-npm.git"
   },
   "scripts": {
-    "test": "standard"
+    "test": "standard && tap test/*.js"
   },
   "main": "./fstream-npm.js",
   "dependencies": {
@@ -16,7 +16,11 @@
     "inherits": "2"
   },
   "devDependencies": {
-    "standard": "^4.3.1"
+    "graceful-fs": "^4.1.2",
+    "mkdirp": "^0.5.1",
+    "rimraf": "^2.4.2",
+    "standard": "^4.3.1",
+    "tap": "^1.3.2"
   },
   "license": "ISC"
 }

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -1,0 +1,95 @@
+var fs = require('graceful-fs')
+var join = require('path').join
+
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var Packer = require('..')
+
+var pkg = join(__dirname, 'test-package')
+
+var gitDir = join(pkg, '.git')
+
+var elfJS = function () {/*
+module.exports = function () {
+  console.log("i'm a elf")
+}
+*/}.toString().split('\n').slice(1, -1).join()
+
+var json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js'
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+var included = [
+  'package.json',
+  'elf.js'
+]
+
+test('follows npm package ignoring rules', function (t) {
+  var subject = new Packer({ path: pkg, type: 'Directory', isDirectory: true })
+  subject.on('entry', function (entry) {
+    t.equal(entry.type, 'File', 'only files in this package')
+    var filename = entry.basename
+    t.ok(
+      included.indexOf(filename) > -1,
+      filename + ' is included'
+    )
+  })
+  // need to do this so fstream doesn't explode when files are removed from
+  // under it
+  subject.on('end', function () { t.end() })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function setup () {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    join(pkg, 'elf.js'),
+    elfJS
+  )
+
+  fs.writeFileSync(
+    join(pkg, '.npmrc'),
+    'packaged=false'
+  )
+
+  var build = join(pkg, 'build')
+  mkdirp.sync(build)
+  fs.writeFileSync(
+    join(build, 'config.gypi'),
+    "i_wont_be_included_by_fstream='with any luck'"
+  )
+
+  fs.writeFileSync(
+    join(build, 'npm-debug.log'),
+    '0 lol\n'
+  )
+
+  mkdirp.sync(gitDir)
+  fs.writeFileSync(
+    join(gitDir, 'gitstub'),
+    "won't fool git, also won't be included by fstream"
+  )
+}
+
+function cleanup () {
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
`config.gypi` is build cruft that shouldn't be published because it includes all kinds of random environment noise, and package-specific `.npmrc` files contain all kinds of project configuration, much of which can be sensitive and easy to overlook while publishing.

Also, this patch adds 🎩tests🐣 (WHAAAAAAT), although coverage is still pretty terrible and it looks like I'm going to have to poke at Travis to make it happy.

**r**: @iarna