### PR TITLE
Allow config.gypi outside of build directory

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -116,7 +116,8 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
       entry === '.hg' ||
       entry === '.lock-wscript' ||
       entry.match(/^\.wafpickle-[0-9]+$/) ||
-      entry === 'config.gypi' ||
+      (this.parent && this.parent.packageRoot && this.basename === 'build' &&
+       entry === 'config.gypi') ||
       entry === 'npm-debug.log' ||
       entry === '.npmrc' ||
       entry.match(/^\..*\.swp$/) ||


### PR DESCRIPTION
Without this, any file named `config.gypi` outside of `node-gyp`'s build directory will be ignored.

Fixes: #13