### PR TITLE
don't rename *.gyp files

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -300,14 +300,6 @@ Packer.prototype.emitEntry = function (entry) {
     entry.path = path.resolve(entry.dirname, entry.basename)
   }
 
-  // all *.gyp files are renamed to binding.gyp for node-gyp
-  // but only when they are in the same folder as a package.json file.
-  if (entry.basename.match(/\.gyp$/) &&
-      this.entries.indexOf('package.json') !== -1) {
-    entry.basename = 'binding.gyp'
-    entry.path = path.resolve(entry.dirname, entry.basename)
-  }
-
   // skip over symbolic links
   if (entry.type === 'SymbolicLink') {
     entry.abort()


### PR DESCRIPTION
Refs https://github.com/npm/read-package-json/pull/52

Currently, `*.gyp` files are all renamed to `binding.gyp` if a `package.json` file exists in the same directory. This can be problematic for packages which use a standalone `gyp` build system outside of just `node-gyp`. This patch removes the current behavior and adds a test case to ensure that `main.gyp` will not be renamed.

**SEMVER MAJOR**

/cc othiym23