### PR TITLE
Always include NOTICE files

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -99,6 +99,9 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
     // license files should never be ignored.
     if (entry.match(/^(license|licence)(\.[^\.]*)?$/i)) return true
 
+    // copyright notice files should never be ignored.
+    if (entry.match(/^(notice)(\.[^\.]*)?$/i)) return true
+
     // changelogs should never be ignored.
     if (entry.match(/^(changes|changelog|history)(\.[^\.]*)?$/i)) return true
   }


### PR DESCRIPTION
This tiny PR adds "NOTICE" to the small category of file names that, if found, are always included in packages.

[Section 4(d) of the Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html#redistribution) requires distribution of licensed works with a copy of the content of the "'NOTICE' text file", if any, that comes with the project's code. Such files typically contain the name of the project and copyright notices (like "Copyright (c) 2015 Joe Schmoe") that other form licenses encourage authors to prepend to the license text itself.

A significant number of npm packages are Apache 2.0 licensed.