### PR TITLE
fstream-npm: do not rename *.gyp twice

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -26,6 +26,8 @@ function Packer (props) {
   this.bundleLinks = props.bundleLinks
   this.package = props.package
 
+  this._renameGyp = true
+
   // only do the magic bundling stuff for the node_modules folder that
   // lives right next to a package.json file.
   this.bundleMagic = this.parent &&
@@ -269,6 +271,10 @@ var order = [
 ]
 
 Packer.prototype.sort = function (a, b) {
+  // put binding.gyp first
+  if (a === 'binding.gyp') return -1
+  if (b === 'binding.gyp') return 1
+
   for (var i = 0, l = order.length; i < l; i++) {
     var o = order[i]
     if (typeof o === 'string') {
@@ -300,10 +306,14 @@ Packer.prototype.emitEntry = function (entry) {
     entry.path = path.resolve(entry.dirname, entry.basename)
   }
 
-  // all *.gyp files are renamed to binding.gyp for node-gyp
+  // first *.gyp file is renamed to binding.gyp for node-gyp
   // but only when they are in the same folder as a package.json file.
-  if (entry.basename.match(/\.gyp$/) &&
+  // NOTE: sort() will put binding.gyp first so that when it is present
+  // no other *.gyp files will be renamed
+  if (this._renameGyp &&
+      entry.basename.match(/\.gyp$/) &&
       this.entries.indexOf('package.json') !== -1) {
+    this._renameGyp = false
     entry.basename = 'binding.gyp'
     entry.path = path.resolve(entry.dirname, entry.basename)
   }

--- a/test/gyp-rename.js
+++ b/test/gyp-rename.js
@@ -1,0 +1,93 @@
+var fs = require('graceful-fs')
+var join = require('path').join
+
+var mkdirp = require('mkdirp')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var Packer = require('..')
+
+var pkg = join(__dirname, 'test-package')
+
+var json = {
+  'name': 'test-package',
+  'version': '3.1.4',
+  'main': 'elf.js'
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+function packAndVerify (t, included) {
+  var subject = new Packer({ path: pkg, type: 'Directory', isDirectory: true })
+  var filenames = []
+  subject.on('entry', function (entry) {
+    t.equal(entry.type, 'File', 'only files in this package')
+
+    filenames.push(entry.basename)
+  })
+  // need to do this so fstream doesn't explode when files are removed from
+  // under it
+  subject.on('end', function () {
+    // ensure we get *exactly* the results we expect by comparing in both
+    // directions
+    filenames.forEach(function (filename) {
+      t.ok(
+        included.indexOf(filename) > -1,
+        filename + ' is included'
+      )
+    })
+    included.forEach(function (filename) {
+      t.ok(
+        filenames.indexOf(filename) > -1,
+        filename + ' is not included'
+      )
+    })
+    t.end()
+  })
+}
+
+test('renames first .gyp file to binding.gyp', function (t) {
+  var included = [
+    'package.json',
+    'binding.gyp'
+  ]
+
+  packAndVerify(t, included)
+})
+
+test('does not rename first .gyp file when binding.gyp present', function (t) {
+  var included = [
+    'package.json',
+    'binding.gyp',
+    'test.gyp'
+  ]
+
+  fs.writeFileSync(
+    join(pkg, 'binding.gyp'),
+    JSON.stringify({}, null, 2)
+  )
+
+  packAndVerify(t, included)
+})
+
+test('cleanup', function (t) {
+  // rimraf.sync chokes here for some reason
+  rimraf(pkg, function () { t.end() })
+})
+
+function setup () {
+  rimraf.sync(pkg)
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  fs.writeFileSync(
+    join(pkg, 'test.gyp'),
+    JSON.stringify({}, null, 2)
+  )
+}


### PR DESCRIPTION
Do not rename multiple *.gyp files to binding.gyp . As a side-effect, no
.gyp files will be renamed if binding.gyp is present.

Fix: https://github.com/npm/npm/issues/8411