### PR TITLE
track missing files

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -2,6 +2,7 @@ var Ignore = require('fstream-ignore')
 var inherits = require('inherits')
 var path = require('path')
 var fs = require('fs')
+var Minimatch = require('minimatch').Minimatch
 
 module.exports = Packer
 
@@ -179,7 +180,16 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   }
   // if (this.bundled) return true
 
-  return Ignore.prototype.applyIgnores.call(this, entry, partial, entryObj)
+  var includeFile = Ignore.prototype.applyIgnores.call(this, entry, partial, entryObj)
+  if (!partial && this.pkgRules && includeFile) {
+    var filesMatched = this.pkgRules.some(function (r) {
+      return (r.match('/' + entry) ||
+              r.match(entry))
+    })
+    return filesMatched
+  }
+
+  return includeFile
 }
 
 Packer.prototype.addIgnoreFiles = function () {
@@ -230,12 +240,13 @@ Packer.prototype.readRules = function (buf, e) {
 
   if (!p.files || !Array.isArray(p.files)) return []
 
-  // ignore everything except what's in the files array.
-  return ['*'].concat(p.files.map(function (f) {
-    return '!' + f
-  })).concat(p.files.map(function (f) {
-    return '!' + f.replace(/\/+$/, '') + '/**'
-  }))
+  var mmopts = { matchBase: true, dot: true }
+  this.pkgRules = p.files.map(function (f) {
+    return [new Minimatch(f, mmopts),
+            new Minimatch(f.replace(/\/+$/, '') + '/**', mmopts)]
+  }).reduce(function (acc, arr) { return acc.concat(arr) }, [])
+
+  return []
 }
 
 Packer.prototype.getChildProps = function (stat) {

--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -183,8 +183,11 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   var includeFile = Ignore.prototype.applyIgnores.call(this, entry, partial, entryObj)
   if (!partial && this.pkgRules && includeFile) {
     var filesMatched = this.pkgRules.some(function (r) {
-      return (r.match('/' + entry) ||
-              r.match(entry))
+      var ruleMatched = (r.match('/' + entry) || r.match(entry))
+      if (ruleMatched) {
+        r.matchedExistingFile = true
+      }
+      return ruleMatched
     })
     return filesMatched
   }
@@ -242,10 +245,11 @@ Packer.prototype.readRules = function (buf, e) {
 
   var mmopts = { matchBase: true, dot: true }
   this.pkgRules = p.files.map(function (f) {
-    return [new Minimatch(f, mmopts),
-            new Minimatch(f.replace(/\/+$/, '') + '/**', mmopts)]
-  }).reduce(function (acc, arr) { return acc.concat(arr) }, [])
-
+    var f2 = f.replace('\/+$/', '')
+    var globRule = new Minimatch('{' + f2 + ',' + f2 + '/**}')
+    globRule.originalPattern = f
+    return globRule
+  })
   return []
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "main": "./fstream-npm.js",
   "dependencies": {
     "fstream-ignore": "^1.0.0",
-    "inherits": "2"
+    "inherits": "2",
+    "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "graceful-fs": "^4.1.2",


### PR DESCRIPTION
This makes it so we keep track of which files from the files array have actually had any matches. npm will then be able to warn about them as needed. This is part of the fix for https://github.com/npm/npm/issues/8791.