### PR TITLE
Never ignore 'browser' file

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -132,6 +132,10 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
   // special rules.  see below.
   if (entry === 'node_modules' && this.packageRoot) return true
 
+  // do not ignore browserify/webpack entry point if present
+  var browser = this.package && this.package.browser
+  if (browser && path.resolve(this.path, entry) === path.resolve(this.path, browser)) return true
+
   // package.json main file should never be ignored.
   var mainFile = this.package && this.package.main
   if (mainFile && path.resolve(this.path, entry) === path.resolve(this.path, mainFile)) return true

--- a/test/ignores.js
+++ b/test/ignores.js
@@ -15,10 +15,17 @@ module.exports = function () {
 }
 */}.toString().split('\n').slice(1, -1).join()
 
+var subJS = function () {/*
+module.exports = function () {
+  console.log("i'm a browser elf in a tree")
+}
+*/}.toString().split('\n').slice(1, -1).join()
+
 var json = {
   'name': 'test-package',
   'version': '3.1.4',
-  'main': 'elf.js'
+  'main': 'elf.js',
+  'browser': 'subdub.js'
 }
 
 test('setup', function (t) {
@@ -29,6 +36,7 @@ test('setup', function (t) {
 var included = [
   'package.json',
   'elf.js',
+  'subdub.js',
   join('deps', 'foo', 'config', 'config.gypi')
 ]
 
@@ -83,13 +91,18 @@ function setup () {
   )
 
   fs.writeFileSync(
+    join(pkg, 'subdub.js'),
+    subJS
+  )
+
+  fs.writeFileSync(
     join(pkg, '.npmrc'),
     'packaged=false'
   )
 
   fs.writeFileSync(
     join(pkg, '.npmignore'),
-    '.npmignore\ndummy\npackage.json'
+    '.npmignore\ndummy\npackage.json\nsub*.js\n'
   )
 
   fs.writeFileSync(


### PR DESCRIPTION
This will prevent issues like
https://github.com/substack/node-browserify/issues/1687, where a user
has a 'files' list, or .npmignore file, and inadvertently tries to
exclude their browserify/webpack entry point.