### PR TITLE
feat(ignores): always ignore package-lock.json

### DIFF
--- a/fstream-npm.js
+++ b/fstream-npm.js
@@ -151,7 +151,9 @@ Packer.prototype.applyIgnores = function (entry, partial, entryObj) {
       entry.match(/^\..*\.swp$/) ||
       entry === '.DS_Store' ||
       entry.match(/^\._/) ||
-      entry.match(/^.*\.orig$/)
+      entry.match(/^.*\.orig$/) ||
+      // Package locks are never allowed in tarballs -- use shrinkwrap instead
+      entry === 'package-lock.json'
     ) {
     return false
   }


### PR DESCRIPTION
BREAKING CHANGE: files named package-lock.json will never be included in publishes

This is the lockfile autogenerated by npm@5, and it's meant to be only for development. npm-shrinkwrap.json will still be included, and the npm behavior is to prioritize that one if present.